### PR TITLE
Add cli option to limit spawn count

### DIFF
--- a/settings/default.toml
+++ b/settings/default.toml
@@ -1,5 +1,7 @@
 default_server = "prod"
 default_packet_forwarder = "default"
+metrics_server = "127.0.0.1"
+metrics_port = 9898
 # if any explicit packet forwarders are defined in settings.toml,
 # this packet forwarder is pruned from the map
 [packet_forwarder.default]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,12 @@ pub use settings::{mac_string_into_buf, Credentials};
 #[derive(Debug, StructOpt)]
 #[structopt(name = "virtual-lorawan-device", about = "LoRaWAN test device utility")]
 pub struct Opt {
+    /// Path to settings subdirectory
     #[structopt(short, long, default_value = "./settings")]
     pub settings: PathBuf,
+    /// Limit number of devices to spawn
+    #[structopt(short, long)]
+    pub limit: Option<usize>,
 }
 
 const DEFAULT_PF: &str = "default";
@@ -49,10 +53,15 @@ async fn main() -> Result<()> {
         (metrics_server, settings.metrics_port).into(),
         settings.get_servers(),
     );
+    let device_limit = if let Some(limit) = cli.limit {
+        limit
+    } else {
+        usize::MAX
+    };
 
     let pf_map = setup_packet_forwarders(settings.packet_forwarder).await?;
 
-    for (label, device) in settings.device {
+    for (label, device) in settings.device.into_iter().take(device_limit) {
         let packet_forwarder = if let Some(pf) = &device.packet_forwarder {
             pf
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
 use log::{debug, error, info, warn};
 use metrics::Metrics;
 use semtech_udp::client_runtime::UdpRuntime;
-use std::{collections::HashMap, net::{SocketAddr, IpAddr}, path::PathBuf, time::Instant};
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+    time::Instant,
+};
 use structopt::StructOpt;
 
 mod error;
@@ -40,8 +45,10 @@ async fn main() -> Result<()> {
     let instant = Instant::now();
     let settings = settings::Settings::new(&cli.settings)?;
     let metrics_server: IpAddr = settings.metrics_server.parse()?;
-    let metrics = Metrics::run((metrics_server, settings.metrics_port).into(),
-                               settings.get_servers());
+    let metrics = Metrics::run(
+        (metrics_server, settings.metrics_port).into(),
+        settings.get_servers(),
+    );
 
     let pf_map = setup_packet_forwarders(settings.packet_forwarder).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use log::{debug, error, info, warn};
 use metrics::Metrics;
 use semtech_udp::client_runtime::UdpRuntime;
-use std::{collections::HashMap, net::SocketAddr, path::PathBuf, time::Instant};
+use std::{collections::HashMap, net::{SocketAddr, IpAddr}, path::PathBuf, time::Instant};
 use structopt::StructOpt;
 
 mod error;
@@ -39,7 +39,9 @@ async fn main() -> Result<()> {
     let cli = Opt::from_args();
     let instant = Instant::now();
     let settings = settings::Settings::new(&cli.settings)?;
-    let metrics = Metrics::run(([127, 0, 0, 1], 9898).into(), settings.get_servers());
+    let metrics_server: IpAddr = settings.metrics_server.parse()?;
+    let metrics = Metrics::run((metrics_server, settings.metrics_port).into(),
+                               settings.get_servers());
 
     let pf_map = setup_packet_forwarders(settings.packet_forwarder).await?;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,8 @@ pub struct Settings {
     pub default_server: String,
     pub device: HashMap<String, Device>,
     pub packet_forwarder: HashMap<String, PacketForwarder>,
+    pub metrics_server: String,
+    pub metrics_port: u16,
 }
 
 impl Settings {


### PR DESCRIPTION
Add command-line interface option `--limit`
- Limit number of devices used from set of configured devices within `settings.toml`
- Useful when 100 or 1000 devices have been configured but a particular run needs only one or two
- Also add Doc comment for `--settings` which becomes visible from `--help`