### PR TITLE
Add setting for slowing down join requests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<()> {
             metrics_sender,
             device.rejoin_frames,
             device.secs_between_transmits,
+            device.secs_between_join_transmits,
             device.region,
         )
         .await?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -46,6 +46,8 @@ pub struct Device {
     pub rejoin_frames: u32,
     #[serde(default = "default_secs_between_transmits")]
     pub secs_between_transmits: u64,
+    #[serde(default = "default_secs_between_join_transmits")]
+    pub secs_between_join_transmits: u64,
     #[serde(default = "default_region")]
     pub region: Region,
     pub server: Option<String>,
@@ -59,7 +61,10 @@ pub enum Region {
 }
 
 fn default_secs_between_transmits() -> u64 {
-    0
+    5
+}
+fn default_secs_between_join_transmits() -> u64 {
+    5
 }
 fn default_rejoin_frames() -> u32 {
     0xFFFF


### PR DESCRIPTION
- Update default time between regular uplinks, 0 is a bit fast
- Allow time between join requests, also defaults to 5 seconds