### PR TITLE
update semtech-udp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,12 +872,12 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semtech-udp"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cca2d25ca92de1e3de8173a945f69992edb64ab8c9846bf4910a992ec4da99"
+version = "0.10.4"
+source = "git+https://github.com/helium/semtech-udp.git#f8d3c9c5cfcfe84893b32b1f2c6f5016aa053aea"
 dependencies = [
  "arrayref",
  "base64",
+ "macaddr",
  "num_enum",
  "rand",
  "serde",
@@ -879,6 +885,7 @@ dependencies = [
  "serde_repr",
  "thiserror",
  "tokio",
+ "triggered",
 ]
 
 [[package]]
@@ -1165,6 +1172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triggered"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce148eae0d1a376c1b94ae651fc3261d9cb8294788b962b7382066376503a2d1"
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1245,7 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio",
+ "triggered",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,21 @@ publish = false
 
 [dependencies]
 anyhow = "1"
+config = { version="0.11", default-features = false, features = ["toml"] }
 env_logger = "0"
 heapless = "0"
 hex = "0"
+hyper = { version = "0", features = ["full"] }
 log = "0"
 lorawan = { git = "https://github.com/helium/rust-lorawan.git" }
 lorawan-device = { git = "https://github.com/helium/rust-lorawan.git" }
-semtech-udp = { version = ">=0.7,<0.8", features=["client"] }
+prometheus = "0"
+semtech-udp = { git = "https://github.com/helium/semtech-udp.git", features = ["client"] }
 serde = "1"
 structopt = "0"
 thiserror = "1"
-config = { version="0.11", default-features=false, features=["toml"]}
 rand = "0"
-prometheus = "0"
-hyper = { version = "0", features = ["full"] }
+triggered = "0"
 
 [dependencies.tokio]
 version = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,4 +21,8 @@ pub enum Error {
     SemtechUdpClientRuntime(#[from] semtech_udp::client_runtime::Error),
     #[error("invalid region string")]
     InvalidRegionString(String),
+    #[error("error sending downlink to upd_radio instance: {0}")]
+    SendingDownlinkToUdpRadio(mpsc::error::SendError<virtual_device::IntermediateEvent>),
+    #[error("receive channel from semtech_udp::client_runtime unexpectedly closed")]
+    RxChannelSemtechUdpClientRuntimeClosed,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,7 @@ async fn packet_muxer(
                                     }
                                 });
                             }
+                            downlink.ack().await?;
                         } else {
                             let time_since_scheduled_time = time - scheduled_time;
                             if time_since_scheduled_time > 1000 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use log::{debug, error, info, warn};
 use metrics::Metrics;
-use semtech_udp::client_runtime::UdpRuntime;
+use semtech_udp::client_runtime;
+use semtech_udp::client_runtime::{ClientRx, ClientTx, UdpRuntime};
 use std::{
     collections::HashMap,
     net::{IpAddr, SocketAddr},
@@ -8,6 +9,7 @@ use std::{
     time::Instant,
 };
 use structopt::StructOpt;
+use tokio::sync::mpsc;
 
 mod error;
 mod metrics;
@@ -58,9 +60,8 @@ async fn main() -> Result<()> {
     } else {
         usize::MAX
     };
-
-    let pf_map = setup_packet_forwarders(settings.packet_forwarder).await?;
-
+    let (trigger, trigger_listener) = triggered::trigger();
+    let mut pf_map = setup_packet_forwarders(settings.packet_forwarder).await?;
     for (label, device) in settings.device.into_iter().take(device_limit) {
         let packet_forwarder = if let Some(pf) = &device.packet_forwarder {
             pf
@@ -74,43 +75,61 @@ async fn main() -> Result<()> {
             &settings.default_server
         });
 
-        let lorawan_app = virtual_device::VirtualDevice::new(
-            label.clone(),
-            instant,
-            if let Some(pf) = pf_map.get(packet_forwarder) {
-                pf
-            } else {
-                panic!("{} is invalid packet forwarder", packet_forwarder)
-            },
-            device.credentials,
-            metrics_sender,
-            device.rejoin_frames,
-            device.secs_between_transmits,
-            device.secs_between_join_transmits,
-            device.region,
-        )
-        .await?;
+        if let Some((_udp_runtime, client_tx, _client_rx, senders)) =
+            pf_map.get_mut(packet_forwarder)
+        {
+            let (packet_sender, lorawan_app) = virtual_device::VirtualDevice::new(
+                label.clone(),
+                instant,
+                client_tx.clone(),
+                device.credentials,
+                metrics_sender,
+                device.rejoin_frames,
+                device.secs_between_transmits,
+                device.secs_between_join_transmits,
+                device.region,
+            )
+            .await?;
 
-        tokio::spawn(async move {
-            if let Err(e) = lorawan_app.run().await {
-                error!("{} device threw error: {:?}", label, e)
-            }
-        });
+            senders.push(packet_sender);
+
+            tokio::spawn(async move {
+                if let Err(e) = lorawan_app.run().await {
+                    error!("{} device threw error: {:?}", label, e)
+                }
+            });
+        } else {
+            panic!("Unknown macaddress linked to device!");
+        }
     }
 
-    for (_, runtime) in pf_map {
-        tokio::spawn(runtime.run());
+    for (_label, (udp_runtime, _client_tx, client_rx, senders)) in pf_map {
+        let shutdown_trigger = trigger_listener.clone();
+        tokio::spawn(udp_runtime.run(shutdown_trigger));
+        let shutdown_trigger = trigger_listener.clone();
+        tokio::spawn(packet_muxer(client_rx, senders, shutdown_trigger));
     }
 
     tokio::signal::ctrl_c().await?;
+    trigger.trigger();
     info!("User exit via ctrl C");
     Ok(())
 }
 
 async fn setup_packet_forwarders(
     mut packet_forwarder: HashMap<String, settings::PacketForwarder>,
-) -> Result<HashMap<String, UdpRuntime>> {
-    // prune the deafult packet forwarder if we have more than one
+) -> Result<
+    HashMap<
+        String,
+        (
+            UdpRuntime,
+            ClientTx,
+            ClientRx,
+            Vec<virtual_device::PacketSender>,
+        ),
+    >,
+> {
+    // prune the default packet forwarder if we have more than one
     if packet_forwarder.len() != 1 && packet_forwarder.contains_key("default") {
         packet_forwarder.remove("default");
     }
@@ -124,14 +143,34 @@ async fn setup_packet_forwarders(
             packet_forwarder.host,
             outbound.to_string()
         );
-        let udp_runtime = UdpRuntime::new(
-            packet_forwarder.mac_cloned_into_buf().unwrap(),
-            outbound,
+        let (sender, receiver, udp_runtime) = UdpRuntime::new(
+            packet_forwarder.mac_cloned_into_buf().unwrap().into(),
             packet_forwarder.host,
         )
         .await?;
-        pf_map.insert(label, udp_runtime);
+        pf_map.insert(label, (udp_runtime, sender, receiver, vec![]));
     }
 
     Ok(pf_map)
+}
+
+async fn packet_muxer(
+    mut client_rx: ClientRx,
+    senders: Vec<virtual_device::PacketSender>,
+    trigger: triggered::Listener,
+) -> Result {
+    tokio::select!(
+        _ = trigger => Ok(()),
+        resp = async move {
+            loop {
+                let msg = client_rx.recv().await.ok_or(Error::RxChannelSemtechUdpClientRuntimeClosed)?;
+                if let client_runtime::Event::DownlinkRequest(downlink) = msg {
+                    let downlink = Box::new(downlink);
+                    for sender in &senders {
+                        sender.send(downlink.clone()).await?;
+                    }
+                }
+            }
+        } => resp
+    )
 }

--- a/src/virtual_device/udp_radio.rs
+++ b/src/virtual_device/udp_radio.rs
@@ -1,17 +1,17 @@
 use log::info;
 use lorawan_device::{radio, Timings};
-use semtech_udp::client_runtime;
-use semtech_udp::{push_data, Bandwidth, CodingRate, DataRate, SpreadingFactor};
+use semtech_udp::client_runtime::{ClientTx, DownlinkRequest};
+use semtech_udp::{Bandwidth, CodingRate, DataRate, SpreadingFactor};
 use std::time::{Duration, Instant};
-pub use tokio::sync::mpsc::{self, Receiver, Sender};
+pub use tokio::sync::mpsc;
 use tokio::time::sleep;
 
 #[derive(Debug)]
 // I need some intermediate event because of Lifetimes
 // maybe there's a cleaner way of doing this
 pub enum IntermediateEvent {
-    UdpRx(Box<semtech_udp::pull_resp::Packet>),
-    RadioEvent(Box<semtech_udp::pull_resp::Packet>, u64),
+    UdpRx(Box<DownlinkRequest>),
+    RadioEvent(Box<DownlinkRequest>, u64),
     NewSession,
     Timeout(usize),
     SendPacket(Vec<u8>, u8, bool),
@@ -22,8 +22,8 @@ pub enum Response {}
 
 #[derive(Debug)]
 pub struct UdpRadio {
-    udp_sender: Sender<client_runtime::TxMessage>,
-    lorawan_sender: Sender<IntermediateEvent>,
+    client_tx: ClientTx,
+    lorawan_sender: mpsc::Sender<IntermediateEvent>,
     time: Instant,
     settings: Settings,
     timeout_id: usize,
@@ -35,36 +35,18 @@ pub struct UdpRadio {
 impl UdpRadio {
     pub async fn new(
         time: Instant,
-        udp_runtime: &semtech_udp::client_runtime::UdpRuntime,
+        client_tx: ClientTx,
     ) -> (
         UdpRadio,
-        tokio::sync::mpsc::Receiver<IntermediateEvent>,
-        tokio::sync::mpsc::Sender<IntermediateEvent>,
+        mpsc::Receiver<IntermediateEvent>,
+        mpsc::Sender<IntermediateEvent>,
     ) {
-        let (mut udp_receiver, udp_sender) = (udp_runtime.subscribe(), udp_runtime.publish_to());
-
         let (lorawan_sender, lorawan_receiver) = mpsc::channel(100);
-        let udp_lorawan_sender = lorawan_sender.clone();
-
-        // this task receives downlinks and sends them to the lorawan layer as if a PHY radio
-        // received the frame
-        tokio::spawn(async move {
-            loop {
-                let event = udp_receiver.recv().await.unwrap();
-                if let semtech_udp::Packet::Down(semtech_udp::Down::PullResp(pull_resp)) = event {
-                    udp_lorawan_sender
-                        .send(IntermediateEvent::UdpRx(pull_resp))
-                        .await
-                        .unwrap();
-                }
-            }
-        });
-
         (
             UdpRadio {
                 time,
                 settings: Settings::default(),
-                udp_sender,
+                client_tx,
                 timeout_id: 0,
                 lorawan_sender: lorawan_sender.clone(),
                 window_start: 0,
@@ -110,7 +92,7 @@ use lorawan_device::radio::{
 impl radio::PhyRxTx for UdpRadio {
     type PhyError = Error;
     type PhyResponse = Response;
-    type PhyEvent = Box<semtech_udp::pull_resp::Packet>;
+    type PhyEvent = Box<DownlinkRequest>;
 
     fn get_mut_radio(&mut self) -> &mut Self {
         self
@@ -145,15 +127,17 @@ impl radio::PhyRxTx for UdpRadio {
                     rssi: -112,
                     rssis: None,
                     size,
-                    stat: semtech_udp::push_data::CRC::OK,
+                    stat: CRC::OK,
                     tmst,
                     time: None,
                 };
-                let packet = push_data::Packet::from_rxpk(RxPk::V1(rxpk));
-
-                if let Err(e) = self.udp_sender.try_send(packet.into()) {
-                    panic!("UdpTx Queue Overflow! {}", e)
-                }
+                let packet = Packet::from_rxpk([0, 0, 0, 0, 0, 0, 0, 0].into(), RxPk::V1(rxpk));
+                let sender = self.client_tx.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = sender.send(packet).await {
+                        panic!("UdpTx Queue Overflow! {}", e)
+                    }
+                });
 
                 // units are in millis here because
                 // the lorawan device stack operates in millis
@@ -167,16 +151,13 @@ impl radio::PhyRxTx for UdpRadio {
             }
             radio::Event::CancelRx => Ok(radio::Response::Idle),
             radio::Event::PhyEvent(packet) => {
-                self.pos = packet.data.txpk.data.len();
-                for (i, el) in packet.data.txpk.data.iter().enumerate() {
+                let data = packet.pull_resp.data.txpk.data.as_ref();
+                self.pos = data.len();
+                for (i, el) in data.iter().enumerate() {
                     self.rx_buffer[i] = *el;
                 }
-                let ack = packet
-                    .into_ack_for_gateway(semtech_udp::MacAddress::new(&[0, 0, 0, 0, 0, 0, 0, 0]));
-
-                let sender = self.udp_sender.clone();
                 // we are not in an async context so we must spawn this off
-                tokio::task::spawn(async move { sender.send(ack.into()).await });
+                tokio::task::spawn(packet.ack());
                 Ok(LoraResponse::RxDone(RxQuality::new(-120, 5)))
             }
         }

--- a/src/virtual_device/udp_radio.rs
+++ b/src/virtual_device/udp_radio.rs
@@ -155,8 +155,6 @@ impl radio::PhyRxTx for UdpRadio {
                 for (i, el) in data.iter().enumerate() {
                     self.rx_buffer[i] = *el;
                 }
-                // we are not in an async context so we must spawn this off
-                tokio::task::spawn(packet.ack());
                 Ok(LoraResponse::RxDone(RxQuality::new(-120, 5)))
             }
         }

--- a/src/virtual_device/udp_radio.rs
+++ b/src/virtual_device/udp_radio.rs
@@ -10,7 +10,6 @@ use tokio::time::sleep;
 // I need some intermediate event because of Lifetimes
 // maybe there's a cleaner way of doing this
 pub enum IntermediateEvent {
-    UdpRx(Box<DownlinkRequest>),
     RadioEvent(Box<DownlinkRequest>, u64),
     NewSession,
     Timeout(usize),


### PR DESCRIPTION
Updates semtech-udp to current master. The biggest change is that semtech_udp's client runtime no longer uses broadcast channel as a client interface. Therefore, virtual-lorawan-device now handles the single `semtech_udp::client_runtime::ClientRx` instance and copies the receive frames to all device instances.